### PR TITLE
Fix file matching

### DIFF
--- a/GPTPullRequestReview/src/pr.ts
+++ b/GPTPullRequestReview/src/pr.ts
@@ -8,7 +8,15 @@ export async function addCommentToPR(fileName: string, comment: string, httpsAge
       {
         parentCommentId: 0,
         content: comment,
-        commentType: 1
+        commentType: 1,
+        startPosition: {
+          line: 1,
+          character: 1
+        },
+        endPosition: {
+          line: 1,
+          character: 1
+        }
       }
     ],
     status: 1,

--- a/GPTPullRequestReview/task.json
+++ b/GPTPullRequestReview/task.json
@@ -41,6 +41,31 @@
       "defaultValue": "false",
       "required": false,
       "helpMarkDown": "Select this option to support self-signed certificate."
+    },
+    {
+      "name": "prompt_instructions",
+      "type": "string",
+      "label": "prompt instructions for auto the code review",
+      "defaultValue": "Act as a code reviewer of a Pull Request, providing feedback on the code changes below.
+            You are provided with the Pull Request changes in a patch format.
+            Each patch entry has the commit message in the Subject line followed by the code changes (diffs) in a unidiff format.",
+      "required": true,
+      "helpMarkDown": "use to set instructions for your reviewer will be injected into your system prompt"
+    },
+    {
+      "name": "model",
+      "type": "string",
+      "label": "OpenAI model name",
+      "defaultValue": "gpt-3.5-turbo",
+      "required": true,
+      "helpMarkDown": "use to set the model to use"
+    }, {
+      "name": "max_token",
+      "type": "number",
+      "label": "OpenAI Token Max Length",
+      "defaultValue": 500,
+      "required": true,
+      "helpMarkDown": "use to set the max length for a result"
     }
   ],
   "execution": {

--- a/GPTPullRequestReview/task.json
+++ b/GPTPullRequestReview/task.json
@@ -46,9 +46,7 @@
       "name": "prompt_instructions",
       "type": "string",
       "label": "prompt instructions for auto the code review",
-      "defaultValue": "Act as a code reviewer of a Pull Request, providing feedback on the code changes below.
-            You are provided with the Pull Request changes in a patch format.
-            Each patch entry has the commit message in the Subject line followed by the code changes (diffs) in a unidiff format.",
+      "defaultValue": "Act as a code reviewer of a Pull Request, providing feedback on the code changes below. You are provided with the Pull Request changes in a patch format.             Each patch entry has the commit message in the Subject line followed by the code changes (diffs) in a unidiff format.",
       "required": true,
       "helpMarkDown": "use to set instructions for your reviewer will be injected into your system prompt"
     },


### PR DESCRIPTION
This pr fixes some issues and adds some features.
Fix: File names were not matching so the comments were not showing up under any files but rather only showing on the Overview tab.
Fix: Handle cases where the response from GPT is `No Feedback` or `- No feedback`
Feature: Allow customization of the model
Feature: Allow customization of the token length
Feature: Allow customization of the prompt