### PR TITLE
Filter out removed files

### DIFF
--- a/GPTPullRequestReview/src/git.ts
+++ b/GPTPullRequestReview/src/git.ts
@@ -15,11 +15,13 @@ export async function getChangedFiles(targetBranch: string) {
   await git.addConfig('core.quotepath', 'false');
   await git.fetch();
 
-  const diffs = await git.diff([targetBranch, '--name-only', '--diff-filter=AM']);
+  const diffs = await git.diff([targetBranch, '--name-only', '--diff-filter=AMD']);
   const files = diffs.split('\n').filter(line => line.trim().length > 0);
-  const nonBinaryFiles = files.filter(file => !binaryExtensions.includes(getFileExtension(file)));
+  const deletedDiffs = await git.diff([targetBranch, '--name-only', '--diff-filter=D']);
+  const deletedFiles = new Set(deletedDiffs.split('\n').filter(line => line.trim().length > 0));
+  const filteredFiles = files.filter(file => !binaryExtensions.includes(getFileExtension(file)) && !deletedFiles.has(file));
 
-  console.log(`Changed Files (excluding binary files) : \n ${nonBinaryFiles.join('\n')}`);
+  console.log(`Changed Files (excluding binary and deleted files) : \n ${filteredFiles.join('\n')}`);
 
-  return nonBinaryFiles;
+  return filteredFiles;
 }


### PR DESCRIPTION
I saw that while running the task in a repo where I had removed files I got errors, therefore those removed files from the diff should be filtered out.