### PR TITLE
Add empty arrays for variables that could be undefined to prevent errors

### DIFF
--- a/GPTPullRequestReview/src/pr.ts
+++ b/GPTPullRequestReview/src/pr.ts
@@ -53,7 +53,7 @@ export async function deleteExistingComments(httpsAgent: Agent) {
     });
 
     const comments = await commentsResponse.json() as { value: [] };
-    const commmentsValues = (comments.value || [])
+    const commmentsValues = comments.value || []
 
     for (const comment of commmentsValues.filter((comment: any) => comment.author.displayName === buildServiceName) as any[]) {
       const removeCommentUrl = `${tl.getVariable('SYSTEM.TEAMFOUNDATIONCOLLECTIONURI')}${tl.getVariable('SYSTEM.TEAMPROJECTID')}/_apis/git/repositories/${tl.getVariable('Build.Repository.Name')}/pullRequests/${tl.getVariable('System.PullRequest.PullRequestId')}/threads/${thread.id}/comments/${comment.id}?api-version=5.1`;

--- a/GPTPullRequestReview/src/pr.ts
+++ b/GPTPullRequestReview/src/pr.ts
@@ -39,7 +39,7 @@ export async function deleteExistingComments(httpsAgent: Agent) {
   });
 
   const threads = await threadsResponse.json() as { value: [] };
-  const threadsWithContext = threads.value.filter((thread: any) => thread.threadContext !== null);
+  const threadsWithContext = (threads.value || []).filter((thread: any) => thread.threadContext !== null);
 
   const collectionUri = tl.getVariable('SYSTEM.TEAMFOUNDATIONCOLLECTIONURI') as string;
   const collectionName = getCollectionName(collectionUri);
@@ -53,8 +53,9 @@ export async function deleteExistingComments(httpsAgent: Agent) {
     });
 
     const comments = await commentsResponse.json() as { value: [] };
+    const commmentsValues = (comments.value || [])
 
-    for (const comment of comments.value.filter((comment: any) => comment.author.displayName === buildServiceName) as any[]) {
+    for (const comment of commmentsValues.filter((comment: any) => comment.author.displayName === buildServiceName) as any[]) {
       const removeCommentUrl = `${tl.getVariable('SYSTEM.TEAMFOUNDATIONCOLLECTIONURI')}${tl.getVariable('SYSTEM.TEAMPROJECTID')}/_apis/git/repositories/${tl.getVariable('Build.Repository.Name')}/pullRequests/${tl.getVariable('System.PullRequest.PullRequestId')}/threads/${thread.id}/comments/${comment.id}?api-version=5.1`;
 
       await fetch(removeCommentUrl, {


### PR DESCRIPTION
Added default empty arrays to handle cases where `threads.value` or `comments.value` might be undefined. This ensures that the code handles these situations gracefully and avoids potential runtime errors.

For `threadsWithContext`: Initialized with an empty array if `threads.value` is `undefined`.
For `commmentsValues`: Added a default empty array if `comments.value` is `undefined`.
These changes improve the stability of the code by preventing errors when accessing properties of potentially undefined values.

#53 